### PR TITLE
Refactor LocationDropDown 

### DIFF
--- a/src/components/LocationDropdown.tsx
+++ b/src/components/LocationDropdown.tsx
@@ -1,12 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useEffect, useMemo, useState } from "react";
-import { DigiContextMenu } from "@digi/arbetsformedlingen-react";
+import { useEffect, useState } from "react";
+import { DigiFormSelectFilter } from "@digi/arbetsformedlingen-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { get } from "../services/serviceBase";
 
-// Join base URL and extra query string properly
-// Handles if extra starts with ? or & or neither
-// Also handles if base already has ? or not
+type Municipality = { code: string; name: string; count: number };
+
+const TEXT = {
+  label: "Ort",
+  placeholder: "Välj ort eller distans",
+  all: "Alla orter",
+  remote: "Distans (remote)",
+};
+
 function joinUrl(base: string, extra?: string) {
   if (!extra || !extra.trim()) return base;
   const e = extra.trim();
@@ -16,143 +22,96 @@ function joinUrl(base: string, extra?: string) {
   return base + (base.includes("?") ? `&${e}` : `?${e}`);
 }
 
-type Kommun = { kod: string; namn: string; antal: number };
-
 export const LocationDropdown = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const baseURL = import.meta.env.VITE_BASE_URL as string;
 
-  const urlParams = useMemo(
-    () => new URLSearchParams(location.search),
-    [location.search]
-  );
+  const [municipalities, setMunicipalities] = useState<Municipality[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  const [kommuner, setKommuner] = useState<Kommun[]>([]);
-  const [laddar, setLaddar] = useState(true);
-  const [visaAlla, setVisaAlla] = useState(false);
-
-  // Fetch municipalities facet on mount and when search changes
   useEffect(() => {
     (async () => {
-      setLaddar(true);
+      setLoading(true);
       try {
         const params = new URLSearchParams(location.search);
+        // don’t facet on itself; reset paging
         params.delete("municipality");
         params.delete("offset");
+
         const url = joinUrl(
           baseURL,
           `${params.toString()}&limit=0&facets=municipality`
         );
         const data = await get<any>(url);
 
-        console.debug("facets.raw:", data?.facets);
-
-        // Try to find facets in different possible structures
         const buckets =
           data?.facets?.municipality ??
           data?.facets?.municipalities ??
           data?.aggregations?.municipality ??
           [];
 
-        console.debug("facets.municipality buckets:", buckets);
-
-        const rows: Kommun[] = buckets.map((b: any) => ({
-          kod: String(b.id ?? b.value ?? b.code ?? ""),
-          namn: String(b.label ?? b.name ?? b.title ?? b.id ?? ""),
-          antal: Number(b.count ?? b.doc_count ?? 0),
+        const rows: Municipality[] = buckets.map((b: any) => ({
+          code: String(b.id ?? b.value ?? b.code ?? ""),
+          name: String(b.label ?? b.name ?? b.title ?? b.id ?? ""),
+          count: Number(b.count ?? b.doc_count ?? 0),
         }));
 
-        rows.sort((a, b) => b.antal - a.antal);
-        setKommuner(rows);
-      } catch (e) {
-        console.error("Kunde inte hämta kommun-facet:", e);
-        setKommuner([]);
+        rows.sort((a, b) => b.count - a.count);
+        setMunicipalities(rows);
+      } catch (err) {
+        console.error("Failed to fetch municipality facets:", err);
+        setMunicipalities([]);
       } finally {
-        setLaddar(false);
+        setLoading(false);
       }
     })();
   }, [location.search, baseURL]);
 
-  //Add or update municipality or remote in URL
-  // Remove offset (go to first page)
-  const sättKommun = (kod: string) => {
+  const updateUrl = (municipality?: string, isRemote?: boolean) => {
     const p = new URLSearchParams(location.search);
-    p.delete("remote");
-    p.set("municipality", kod);
     p.delete("offset");
+    if (municipality) {
+      p.delete("remote");
+      p.set("municipality", municipality);
+    } else if (isRemote) {
+      p.delete("municipality");
+      p.set("remote", "true");
+    } else {
+      p.delete("municipality");
+      p.delete("remote");
+    }
     navigate(`/search?${p.toString()}`, { replace: true });
   };
 
-  const sättDistans = () => {
-    const p = new URLSearchParams(location.search);
-    p.delete("municipality");
-    p.set("remote", "true");
-    p.delete("offset");
-    navigate(`/search?${p.toString()}`, { replace: true });
-  };
-
-  const rensa = () => {
-    const p = new URLSearchParams(location.search);
-    p.delete("municipality");
-    p.delete("remote");
-    p.delete("offset");
-    navigate(`/search?${p.toString()}`, { replace: true });
-  };
-
-  // Meny items
-  const synligaKommuner = visaAlla ? kommuner : kommuner.slice(0, 20);
-
-  const meny = [
-    { id: 0, title: "Alla orter", onClick: rensa },
-    { id: 1, title: "Distans (remote)", onClick: sättDistans },
-    {
-      id: 2,
-      title: "Sök ort …",
-      onClick: () => {
-        const input = window
-          .prompt("Skriv ort/kommun (t.ex. Lund, Stockholm):")
-          ?.trim();
-        if (!input) return;
-        const needle = input.toLocaleLowerCase("sv-SE");
-        const match = kommuner.find((k) =>
-          k.namn.toLocaleLowerCase("sv-SE").includes(needle)
-        );
-        if (match) sättKommun(match.kod);
-        else window.alert(`Hittade ingen kommun som matchar: ${input}`);
-      },
-    },
-
-    // Add municipalities from facet
-    ...synligaKommuner.map((k, i) => ({
-      id: 100 + i,
-      title: `${k.namn} (${k.antal})`,
-      onClick: () => sättKommun(k.kod),
+  const options = [
+    { value: "", label: "Alla orter" },
+    { value: "remote", label: "Distans (remote)" },
+    ...municipalities.map((m) => ({
+      value: m.code,
+      label: `${m.name} (${m.count})`,
+      lang: "sv",
     })),
-    ...(kommuner.length > 20 && !visaAlla
-      ? [{ id: 9999, title: "Visa fler…", onClick: () => setVisaAlla(true) }]
-      : []),
   ];
 
-  // Title for dropdown
-  const aktuellTitel = (() => {
-    const muni = urlParams.get("municipality");
-    const remote = urlParams.get("remote");
-    if (remote === "true") return "Ort: Distans";
-    if (muni) {
-      const träff = kommuner.find((k) => k.kod === muni);
-      return träff ? `Ort: ${träff.namn}` : "Ort";
-    }
-    return laddar ? "Ort (laddar…)" : "Ort";
+  const selected = (() => {
+    const usp = new URLSearchParams(location.search);
+    const muni = usp.get("municipality");
+    const remote = usp.get("remote");
+    if (remote === "true") return "remote";
+    return muni ?? "";
   })();
 
   return (
-    <DigiContextMenu
-      afTitle={aktuellTitel}
-      afMenuItems={meny}
-      onAfChangeItem={(e: CustomEvent) => {
-        const item = (e as any).detail?.item;
-        item?.onClick?.();
+    <DigiFormSelectFilter
+      afOptions={options}
+      afValue={selected}
+      afIsLoading={loading}
+      onAfOnChange={(e: CustomEvent) => {
+        const val = (e as any).detail.value;
+        if (val === "remote") updateUrl(undefined, true);
+        else if (val) updateUrl(val);
+        else updateUrl();
       }}
     />
   );

--- a/src/components/LocationDropdown.tsx
+++ b/src/components/LocationDropdown.tsx
@@ -9,6 +9,7 @@ type Municipality = { code: string; name: string; count: number };
 type AFListItem = {
   value: string;
   label: string;
+  text?: string;
   selected?: boolean;
   lang?: string;
   dir?: "ltr" | "rtl";
@@ -90,27 +91,34 @@ export const LocationDropdown = () => {
     ...municipalities.map<AFListItem>((m) => ({
       value: m.code,
       label: `${m.name} (${m.count})`,
+      text: `${m.name} (${m.count})`,
       selected: false,
       lang: "sv",
     })),
   ];
 
-  // Selected must also be IListItem[] (even single select)
   const usp = new URLSearchParams(location.search);
   const selectedValue =
     usp.get("remote") === "true" ? "remote" : usp.get("municipality") ?? "";
-  const selectedItems: AFListItem[] = items.filter(
-    (i) => i.value === selectedValue
-  );
 
   return (
     <DigiFormSelectFilter
       {...({
+        afLabel: "Ort",
         afItems: items,
-        afValue: selectedItems,
+        afValue: selectedValue,
         afIsLoading: loading,
         onAfSelect: (e: any) => {
           const val = e?.detail?.value as string | undefined;
+          if (val === "remote") updateUrl(undefined, true);
+          else if (val) updateUrl(val);
+          else updateUrl();
+        },
+        items,
+        value: items.filter((i) => i.value === selectedValue),
+        isLoading: loading,
+        onValueChange: (vals: AFListItem[]) => {
+          const val = vals?.[0]?.value as string | undefined;
           if (val === "remote") updateUrl(undefined, true);
           else if (val) updateUrl(val);
           else updateUrl();

--- a/src/components/SortingDropdown.tsx
+++ b/src/components/SortingDropdown.tsx
@@ -10,6 +10,7 @@ const applyDateAsc = import.meta.env.VITE_SORT_APPLYDATE_ASC;
 const pubDateAsc = import.meta.env.VITE_SORT_PUBDATE_ASC;
 const pubDateDesc  = import.meta.env.VITE_SORT_PUBDATE_DESC;
 
+
 const menuItems = [
     { id: 0, title: "Ansökningsdatum", onClick: () => onSort(applyDateAsc)},
     { id: 1, title: "Publiceringsdatum (äldst först)", onClick: () => onSort(pubDateAsc)},


### PR DESCRIPTION
- Refactors the city/municipality filter to use AF(DigiFormSelectFilter) web-component with afLabel/afItems/afValue.
- Build items from facets (sorted by count) and add `label` + `text`.
- Add “Distans (remote)” and “Alla orter”, clear offset on change.
//TODO check this because is not 100% working//